### PR TITLE
Schedule function to run every 10 minutes

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -65,6 +65,7 @@ functions:
     handler: src/index.handler
     timeout: 30
     events:
+      - schedule: rate(10 minutes)
       - http: # See https://www.serverless.com/framework/docs/providers/aws/events/apigateway/
           path: webhook
           method: post


### PR DESCRIPTION
The rest of the pipeline currently isn't event driven. dbt Cloud is scheduled to run every 10 mins to update BigQuery and doesn't appear to have any webhook/event capability.

I'm just going to leave the webhook functionality there in case it is desired later.