### PR TITLE
TS was complaining that the variable error was not the correct type.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,6 @@ export async function handler() {
     };
   } catch (error) {
     console.error(error);
-    await rollbar.error(error.message, error);
+    await rollbar.error((error as Error).message, error as Error);
   }
 }


### PR DESCRIPTION
## Description
TS complained that the variable `error` wasn't the correct type for the Rollbar function as it was unknown.

## Changes
- Set type as error to stop TS producing an error.