### PR TITLE
Add an TypeScript CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  typescript:
+    runs-on: ubuntu-latest
+    name: ✅ TypeScript Lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+      - name: Enable Corepack
+        run: corepack enable
+      - name: 📦 Install Dependencies
+        run: yarn install
+
+      - name: ✅ TypeScript lint
+        run: yarn lint:ts

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "PROJECT_NAME=content-based-filtering ENVIRONMENT=development serverless invoke local --function handler",
     "lint": "standard || exit 0",
     "lint:fix": "standard --fix || exit 0",
+    "lint:ts": "tsc --noEmit",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
## Description
In this PR, I've added a TypeScript CI test to ensure the TypeScript Code is correct before merging into `main`.

The `tsc --noEmit` command runs TypeScript but doesn't emit any files.